### PR TITLE
Feature/fix markdups mem calc

### DIFF
--- a/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
+++ b/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
@@ -172,7 +172,7 @@ arguments:
     valueFrom: '50000'
   - position: 0
     prefix: '--java-options'
-    valueFrom: '-Xms$(parseInt(runtime.ram)/2000)g -Xmx$(parseInt(runtime.ram)/1000)g'
+    valueFrom: '-Xms$(Math.floor(parseInt(runtime.ram)/2000))g -Xmx$(Math.floor(parseInt(runtime.ram)/1000))g'
 requirements:
   - class: ResourceRequirement
     ramMin: 30100

--- a/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
+++ b/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
@@ -172,7 +172,7 @@ arguments:
     valueFrom: '50000'
   - position: 0
     prefix: '--java-options'
-    valueFrom: '-Xms$(Math.floor(parseInt(runtime.ram)/2048))g -Xmx$((Math.floor(parseInt(runtime.ram)/1024)/(runtime.cpu))*(runtime.cpu))g'
+    valueFrom: '-Xms$(Math.floor(parseInt(runtime.ram)/2048))g -Xmx$((Math.floor(parseInt(runtime.ram)/1024)/(runtime.cores))*(runtime.cores))g'
 requirements:
   - class: ResourceRequirement
     ramMin: 30100

--- a/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
+++ b/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
@@ -172,7 +172,7 @@ arguments:
     valueFrom: '50000'
   - position: 0
     prefix: '--java-options'
-    valueFrom: '-Xms$(Math.floor(parseInt(runtime.ram)/2048))g -Xmx$(Math.floor(parseInt(runtime.ram)/1024))g'
+    valueFrom: '-Xms$(Math.floor(parseInt(runtime.ram)/2048))g -Xmx$(Math.floor(parseInt(runtime.ram)/1024) - 1)g'
 requirements:
   - class: ResourceRequirement
     ramMin: 32800

--- a/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
+++ b/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
@@ -172,7 +172,7 @@ arguments:
     valueFrom: '50000'
   - position: 0
     prefix: '--java-options'
-    valueFrom: '-Xms$(Math.floor(parseInt(runtime.ram)/2048))g -Xmx$(Math.floor(parseInt(runtime.ram)/1024))g'
+    valueFrom: '-Xms$(Math.floor(parseInt(runtime.ram)/2048))g -Xmx$((Math.floor(parseInt(runtime.ram)/1024)/(runtime.cpu))*(runtime.cpu))g'
 requirements:
   - class: ResourceRequirement
     ramMin: 30100

--- a/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
+++ b/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
@@ -172,7 +172,7 @@ arguments:
     valueFrom: '50000'
   - position: 0
     prefix: '--java-options'
-    valueFrom: '-Xms$(Math.floor(parseInt(runtime.ram)/2000))g -Xmx$(Math.floor(parseInt(runtime.ram)/1000))g'
+    valueFrom: '-Xms$(Math.floor(parseInt(runtime.ram)/2048))g -Xmx$(Math.floor(parseInt(runtime.ram)/1024))g'
 requirements:
   - class: ResourceRequirement
     ramMin: 30100

--- a/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
+++ b/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
@@ -172,10 +172,10 @@ arguments:
     valueFrom: '50000'
   - position: 0
     prefix: '--java-options'
-    valueFrom: '-Xms$(Math.floor(parseInt(runtime.ram)/2048))g -Xmx$((Math.floor(parseInt(runtime.ram)/1024)/(runtime.cores))*(runtime.cores))g'
+    valueFrom: '-Xms$(Math.floor(parseInt(runtime.ram)/2048))g -Xmx$(Math.floor(parseInt(runtime.ram)/1024))g'
 requirements:
   - class: ResourceRequirement
-    ramMin: 30100
+    ramMin: 32800
     coresMin: 4
   - class: DockerRequirement
     dockerPull: 'broadinstitute/gatk:4.1.0.0'

--- a/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
+++ b/flatbush_make_bam_and_qc/preprocess_tumor_normal_bam/bam_preprocessing/align_sample/command_line_tools/gatk_4.1.0.0/gatk_mark_duplicates.cwl
@@ -172,10 +172,10 @@ arguments:
     valueFrom: '50000'
   - position: 0
     prefix: '--java-options'
-    valueFrom: '-Xms$(parseInt(runtime.ram)/2000)g -Xmx$(parseInt(runtime.ram)/1000 - 1)g'
+    valueFrom: '-Xms$(parseInt(runtime.ram)/2000)g -Xmx$(parseInt(runtime.ram)/1000)g'
 requirements:
   - class: ResourceRequirement
-    ramMin: 32000
+    ramMin: 30100
     coresMin: 4
   - class: DockerRequirement
     dockerPull: 'broadinstitute/gatk:4.1.0.0'


### PR DESCRIPTION
The `Math.floor` call might be unnecessary; the key change is the `ramMin` value and the `-1` to make sure picard doesn't use more than allocated.